### PR TITLE
Introduce winners for 2020, update landing for React Summit 2021

### DIFF
--- a/react/2018.html
+++ b/react/2018.html
@@ -158,6 +158,7 @@
               <div class="archive-block__title">Nominees <span>for</span></div>
 
               <ul class="archive-list">
+                <li class="archive-list__item"><a class="archive-list__link" href="/react/2020">2020</a></li>
                 <li class="archive-list__item"><a class="archive-list__link" href="/react/2019">2019</a></li>
                 <li class="archive-list__item active"><a class="archive-list__link" href="#">2018</a></li>
               </ul>
@@ -310,6 +311,7 @@
             class="archive-list"
             data-flickity='{ "cellAlign": "left", "contain": true, "prevNextButtons":false, "pageDots":false, "initialIndex": 0 }'
           >
+            <div class="archive-list__item"><a class="archive-list__link" href="/react/2020">2020</a></div>
             <div class="archive-list__item"><a class="archive-list__link" href="/react/2019">2019</a></div>
             <div class="archive-list__item active"><a class="archive-list__link" href="#">2018</a></div>
           </div>

--- a/react/2020.html
+++ b/react/2020.html
@@ -11,7 +11,7 @@
     />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta property="og:image" content="https://osawards.com/react/img/og-image.jpg?v3" />
-    <meta property="og:url" content="https://osawards.com/react/2019" />
+    <meta property="og:url" content="https://osawards.com/react/2020" />
     <meta property="og:title" content="React Open Source Awards - GitNation" />
     <meta
       property="og:description"
@@ -159,8 +159,8 @@
               <div class="archive-block__title">Nominees <span>for</span></div>
 
               <ul class="archive-list">
-                <li class="archive-list__item"><a class="archive-list__link" href="/react/2020">2020</a></li>
-                <li class="archive-list__item active"><a class="archive-list__link" href="#">2019</a></li>
+                <li class="archive-list__item active"><a class="archive-list__link" href="#">2020</a></li>
+                <li class="archive-list__item"><a class="archive-list__link" href="/react/2019">2019</a></li>
                 <li class="archive-list__item"><a class="archive-list__link" href="/react/2018">2018</a></li>
               </ul>
             </div>
@@ -184,14 +184,14 @@
 
                 <div class="winners__nominee-winner">
                   <div class="winners__winner-left">
-                    <img src="pic/immer.png" height="160" width="160" />
+                    <img src="pic/project_dummy.jpg" height="160" width="160" />
                   </div>
 
                   <div class="winners__winner-right">
-                    <h3 class="winners__winner-title">Immer</h3>
-                    <p class="winners__winner-link"><a href="#">github.com/mweststrate/immer</a></p>
+                    <h3 class="winners__winner-title">React Three Fiber</h3>
+                    <p class="winners__winner-link"><a href="#">github.com/react-spring/react-three-fiber</a></p>
                     <p class="winners__winner-desc">
-                      Create the next immutable state by mutating the current one.
+                      A react reconciler for threejs (web and react-native)
                     </p>
                   </div>
                 </div>
@@ -210,13 +210,13 @@
 
                 <div class="winners__nominee-winner">
                   <div class="winners__winner-left">
-                    <img src="pic/vx.png" height="160" width="160" />
+                    <img src="pic/project_dummy.jpg" height="160" width="160" />
                   </div>
 
                   <div class="winners__winner-right">
-                    <h3 class="winners__winner-title">VX</h3>
-                    <p class="winners__winner-link"><a href="#">github.com/hshoff/vx</a></p>
-                    <p class="winners__winner-desc">react + d3 = vx | visualization components.</p>
+                    <h3 class="winners__winner-title">React Adaptive Hooks</h3>
+                    <p class="winners__winner-link"><a href="#">github.com/GoogleChromeLabs/react-adaptive-hooks</a></p>
+                    <p class="winners__winner-desc">Deliver experiences best suited to a user's device and network constraints</p>
                   </div>
                 </div>
               </li>
@@ -234,14 +234,14 @@
 
                 <div class="winners__nominee-winner">
                   <div class="winners__winner-left">
-                    <img src="pic/react95.png" height="160" width="160" />
+                    <img src="pic/never-blink.png" height="160" width="160" />
                   </div>
 
                   <div class="winners__winner-right">
-                    <h3 class="winners__winner-title">React 95</h3>
-                    <p class="winners__winner-link"><a href="#">github.com/React95/React95</a></p>
+                    <h3 class="winners__winner-title">Never-Blink</h3>
+                    <p class="winners__winner-link"><a href="#">github.com/ByronHsu/Never-Blink</a></p>
                     <p class="winners__winner-desc">
-                      A React components library with Win95 UI.
+                      Blink and lose.
                     </p>
                   </div>
                 </div>
@@ -259,14 +259,14 @@
 
                 <div class="winners__nominee-winner">
                   <div class="winners__winner-left">
-                    <img src="pic/react-testing-library.png" height="160" width="160" />
+                    <img src="pic/chakra.png" height="160" width="160" />
                   </div>
 
                   <div class="winners__winner-right">
-                    <h3 class="winners__winner-title">react-testing-library</h3>
-                    <p class="winners__winner-link"><a href="#">github.com/kentcdodds/react-testing-library</a></p>
+                    <h3 class="winners__winner-title">Chakra UI</h3>
+                    <p class="winners__winner-link"><a href="#">github.com/chakra-ui/chakra-ui</a></p>
                     <p class="winners__winner-desc">
-                      Simple and complete React DOM testing utilities that encourage good testing practices.
+                      Simple, Modular & Accessible UI Components for your React Applications
                     </p>
                   </div>
                 </div>
@@ -285,14 +285,14 @@
 
                 <div class="winners__nominee-winner">
                   <div class="winners__winner-left">
-                    <img src="pic/project_dummy.jpg" height="160" width="160" />
+                    <img src="pic/react-hook-form.png" height="160" width="160" />
                   </div>
 
                   <div class="winners__winner-right">
-                    <h3 class="winners__winner-title">mdx-deck</h3>
-                    <p class="winners__winner-link"><a href="#">github.com/jxnblk/mdx-deck</a></p>
+                    <h3 class="winners__winner-title">React Hook Form</h3>
+                    <p class="winners__winner-link"><a href="#">github.com/react-hook-form/react-hook-form</a></p>
                     <p class="winners__winner-desc">
-                      MDX-based presentation decks.
+                      React hooks for forms validation without the hassle.
                     </p>
                   </div>
                 </div>
@@ -306,8 +306,8 @@
             class="archive-list"
             data-flickity='{ "cellAlign": "left", "contain": true, "prevNextButtons":false, "pageDots":false, "initialIndex": 0 }'
           >
-            <div class="archive-list__item"><a class="archive-list__link" href="/react/2020">2020</a></div>
-            <div class="archive-list__item active"><a class="archive-list__link" href="#">2019</a></div>
+            <div class="archive-list__item active"><a class="archive-list__link" href="#">2020</a></div>
+            <div class="archive-list__item"><a class="archive-list__link" href="/react/2019">2018</a></div>
             <div class="archive-list__item"><a class="archive-list__link" href="/react/2018">2018</a></div>
           </div>
         </section>

--- a/react/index.html
+++ b/react/index.html
@@ -233,14 +233,14 @@
 
             <div class="ceremony__content container">
               <div class="ceremony__desc">
-                <h4 class="section__sub-title" data-aos="fade-in" data-aos-delay="100">React Amsterdam Conference</h4>
+                <h4 class="section__sub-title" data-aos="fade-in" data-aos-delay="100">React Summit</h4>
                 <p class="section__desc" data-aos="fade-in" data-aos-delay="200">
-                  The biggest React conference in the world will host its third annual edition of the React Open Source
+                  The biggest React conference in the world will host its fourth annual edition of the React Open Source
                   Awards and will gather community leaders and top contributors from around the world.<br />
-                  <span>October 15, 2020</span>
+                  <span>April 14th, 2021</span>
                 </p>
 
-                <a class="ceremony__more" href="http://react.amsterdam" data-aos="fade-left" data-aos-delay="300">
+                <a class="ceremony__more" href="https://remote.reactsummit.com/" data-aos="fade-left" data-aos-delay="300">
                   Details
                   <svg class="arrow-r" role="img" aria-hidden="true">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="img/sprite-inline.svg#arrow-r"></use>
@@ -251,7 +251,7 @@
           </div>
         </section>
 
-        <section class="section nominees" id="nominees">
+        <!-- <section class="section nominees" id="nominees">
           <div class="container">
             <div class="slider-nav-wrap">
               <h3 class="section__title" data-aos="fade-left">2020 nominees</h3>
@@ -645,7 +645,7 @@
               </li>
             </ul>
           </div>
-        </section>
+        </section> -->
 
         <!--<section class="section jury" id="jury">-->
         <!--<div class="container">-->


### PR DESCRIPTION
### Why 
The third annual edition of React Summit has finished and it's time for a new event. 

### What
- [x] Added `/2020` page with all the OSAwards winners to it
- [x] Updated desktop / mobile menus to include `/2020` year
- [x] Introduce 4th React Summit event  