### PR TITLE
Update JSNation Conf related page contents

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@
                           inspiring engineers and code artists to share their experiences and the vision of the modern
                           development.<br />
                           In 2022, JSNation will host its fourth annual JavaScript Open Source Awards ceremony. In the
-                          meantime, take a look at the list of the 2022 winners.
+                          meantime, take a look at the list of the 2021 winners.
                         </p>
                         <p><strong>June 16, 2022</strong> <br /><strong>JSNation Conference</strong></p>
                         <p><a href="/javascript">osawards.com/javascript</a></p>

--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
                         <img src="./pic/tile-1.svg" alt="" />
                       </div>
                       <h4>JavaScript Open Source Awards</h4>
-                      <p>June 9, 2021 <br />JSNation Live</p>
+                      <p>June 16, 2022 <br />JSNation Conference</p>
                       <span href="/javascript">osawards.com/javascript</span>
                     </div>
                   </a>
@@ -190,13 +190,13 @@
                         <p><img src="./pic/tile-1-white.svg" width="65" alt="" /></p>
                         <h3>JavaScript Open Source Awards</h3>
                         <p>
-                          JSNation is a JavaScript and Node.js oriented conference, gathering core library authors,
+                          JSNation is a JavaScript oriented conference, gathering core library authors,
                           inspiring engineers and code artists to share their experiences and the vision of the modern
                           development.<br />
-                          In 2021, JSNation will host its third annual JavaScript Open Source Awards ceremony. In the
-                          meantime, take a look at the list of the 2020 winners.
+                          In 2022, JSNation will host its fourth annual JavaScript Open Source Awards ceremony. In the
+                          meantime, take a look at the list of the 2022 winners.
                         </p>
-                        <p><strong>June 9, 2021</strong> <br /><strong>JSNation Live</strong></p>
+                        <p><strong>June 16, 2022</strong> <br /><strong>JSNation Conference</strong></p>
                         <p><a href="/javascript">osawards.com/javascript</a></p>
                       </div>
                     </div>

--- a/javascript/index.html
+++ b/javascript/index.html
@@ -213,12 +213,12 @@
                 JSNation Live Conference
               </h4>
               <p class="section__desc" data-aos="fade-in" data-aos-delay="200">
-                The biggest JavaScript conference in the cloud will host its fourth annual edition of the JS Open Source awards.
+                The biggest JavaScript conference will host its fourth annual edition of the JS Open Source awards.
                 <br />
-                <span>June, 2021</span>
+                <span>June 16, 2022</span>
               </p>
 
-              <a class="ceremony__more" href="https://live.jsnation.com/" data-aos="fade-left" data-aos-delay="300">
+              <a class="ceremony__more" href="https://jsnation.com/" data-aos="fade-left" data-aos-delay="300">
                 Details
                 <svg class="arrow-r" role="img" aria-hidden="true">
                   <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="img/sprite-inline.svg#arrow-r"></use>

--- a/javascript/index.html
+++ b/javascript/index.html
@@ -210,7 +210,7 @@
           <div class="ceremony__content container">
             <div class="ceremony__desc">
               <h4 class="section__sub-title" data-aos="fade-in" data-aos-delay="100">
-                JSNation Live Conference
+                JSNation Conference
               </h4>
               <p class="section__desc" data-aos="fade-in" data-aos-delay="200">
                 The biggest JavaScript conference will host its fourth annual edition of the JS Open Source awards.


### PR DESCRIPTION
## Proposed changes

1. On OSAwards landing page:
- Update Conf dates on hover item
- Change Conf Naming from Live to Conference and edit description

2. On /javascript landing page:
- Updating Conf hyperlink
- Update Conf dates & 2022 naming