### PR TITLE
Resolved links to nominees pages and nominees project pages

### DIFF
--- a/javascript/index.html
+++ b/javascript/index.html
@@ -84,7 +84,7 @@
         <nav class="main-nav">
           <ul class="main-menu">
             <li class="main-menu__item"><a class="main-menu__link" href="#ceremony">Ceremony location</a></li>
-            <li class="main-menu__item"><a class="main-menu__link" href="#nominees">Nominees</a></li>
+            <li class="main-menu__item"><a class="main-menu__link" href="nominees">Nominees</a></li>
             <li class="main-menu__item"><a class="main-menu__link" href="/javascript/2021">Previous years</a></li>
           </ul>
         </nav>

--- a/react/2018.html
+++ b/react/2018.html
@@ -188,7 +188,7 @@
 
                   <div class="winners__winner-right">
                     <h3 class="winners__winner-title">Apollo GraphQL</h3>
-                    <p class="winners__winner-link"><a href="apollographql.com">apollographql.com</a></p>
+                    <p class="winners__winner-link"><a href="https://apollographql.com">apollographql.com</a></p>
                     <p class="winners__winner-desc">
                       Apollo provides a universal GraphQL API on top of your existing services, so you can build new
                       application features fast without waiting on backend changes.
@@ -215,7 +215,7 @@
 
                   <div class="winners__winner-right">
                     <h3 class="winners__winner-title">CodeSandbox</h3>
-                    <p class="winners__winner-link"><a href="codesandbox.io">codesandbox.io</a></p>
+                    <p class="winners__winner-link"><a href="https://codesandbox.io">codesandbox.io</a></p>
                     <p class="winners__winner-desc">An online code editor tailored for web applications.</p>
                   </div>
                 </div>
@@ -239,7 +239,9 @@
 
                   <div class="winners__winner-right">
                     <h3 class="winners__winner-title">React Kawaii</h3>
-                    <p class="winners__winner-link"><a href="https://github.com/miukimiu/react-kawaii">github.com/miukimiu/react-kawaii</a></p>
+                    <p class="winners__winner-link">
+                      <a href="https://github.com/miukimiu/react-kawaii">github.com/miukimiu/react-kawaii</a>
+                    </p>
                     <p class="winners__winner-desc">
                       React Kawaii is a library of cute SVG illustrations (react components). Ideal if you want to give
                       some cuteness and personality to your react application.
@@ -360,7 +362,7 @@
               target="_blank"
               novalidate
             >
-              <div style="position: absolute; left: -5000px;" aria-hidden="true">
+              <div style="position: absolute; left: -5000px" aria-hidden="true">
                 <input type="text" name="b_910284f989b81c945f27311af_b1be3f216e" tabindex="-1" value="" />
               </div>
               <input
@@ -382,7 +384,7 @@
 
     <script type="text/javascript">
       var _gauges = _gauges || [];
-      (function() {
+      (function () {
         var t = document.createElement("script");
         t.type = "text/javascript";
         t.async = true;

--- a/react/2018.html
+++ b/react/2018.html
@@ -188,7 +188,7 @@
 
                   <div class="winners__winner-right">
                     <h3 class="winners__winner-title">Apollo GraphQL</h3>
-                    <p class="winners__winner-link"><a href="#">apollographql.com</a></p>
+                    <p class="winners__winner-link"><a href="apollographql.com">apollographql.com</a></p>
                     <p class="winners__winner-desc">
                       Apollo provides a universal GraphQL API on top of your existing services, so you can build new
                       application features fast without waiting on backend changes.
@@ -215,7 +215,7 @@
 
                   <div class="winners__winner-right">
                     <h3 class="winners__winner-title">CodeSandbox</h3>
-                    <p class="winners__winner-link"><a href="#">codesandbox.io</a></p>
+                    <p class="winners__winner-link"><a href="codesandbox.io">codesandbox.io</a></p>
                     <p class="winners__winner-desc">An online code editor tailored for web applications.</p>
                   </div>
                 </div>
@@ -239,7 +239,7 @@
 
                   <div class="winners__winner-right">
                     <h3 class="winners__winner-title">React Kawaii</h3>
-                    <p class="winners__winner-link"><a href="#">github.com/miukimiu/react-kawaii</a></p>
+                    <p class="winners__winner-link"><a href="https://github.com/miukimiu/react-kawaii">github.com/miukimiu/react-kawaii</a></p>
                     <p class="winners__winner-desc">
                       React Kawaii is a library of cute SVG illustrations (react components). Ideal if you want to give
                       some cuteness and personality to your react application.
@@ -265,7 +265,7 @@
 
                   <div class="winners__winner-right">
                     <h3 class="winners__winner-title">Storybook</h3>
-                    <p class="winners__winner-link"><a href="#">storybook.js.org</a></p>
+                    <p class="winners__winner-link"><a href="https://storybook.js.org">storybook.js.org</a></p>
                     <p class="winners__winner-desc">
                       Storybook is a development environment for UI components. It allows you to browse a component
                       library, view the different states of each component, and interactively develop and test
@@ -293,7 +293,7 @@
 
                   <div class="winners__winner-right">
                     <h3 class="winners__winner-title">Prettier</h3>
-                    <p class="winners__winner-link"><a href="#">prettier.io</a></p>
+                    <p class="winners__winner-link"><a href="https://prettier.io">prettier.io</a></p>
                     <p class="winners__winner-desc">
                       Prettier is an opinionated code formatter. It enforces a consistent style by parsing your code and
                       re-printing it with its own rules that take the maximum line length into account, wrapping code

--- a/react/2019.html
+++ b/react/2019.html
@@ -189,7 +189,7 @@
 
                   <div class="winners__winner-right">
                     <h3 class="winners__winner-title">Immer</h3>
-                    <p class="winners__winner-link"><a href="github.com/mweststrate/immer">github.com/mweststrate/immer</a></p>
+                    <p class="winners__winner-link"><a href="https://github.com/mweststrate/immer">github.com/mweststrate/immer</a></p>
                     <p class="winners__winner-desc">
                       Create the next immutable state by mutating the current one.
                     </p>
@@ -215,7 +215,7 @@
 
                   <div class="winners__winner-right">
                     <h3 class="winners__winner-title">VX</h3>
-                    <p class="winners__winner-link"><a href="github.com/hshoff/vx">github.com/hshoff/vx</a></p>
+                    <p class="winners__winner-link"><a href="https://github.com/hshoff/vx">github.com/hshoff/vx</a></p>
                     <p class="winners__winner-desc">react + d3 = vx | visualization components.</p>
                   </div>
                 </div>
@@ -239,7 +239,7 @@
 
                   <div class="winners__winner-right">
                     <h3 class="winners__winner-title">React 95</h3>
-                    <p class="winners__winner-link"><a href="github.com/React95/React95">github.com/React95/React95</a></p>
+                    <p class="winners__winner-link"><a href="https://github.com/React95/React95">github.com/React95/React95</a></p>
                     <p class="winners__winner-desc">
                       A React components library with Win95 UI.
                     </p>
@@ -264,7 +264,7 @@
 
                   <div class="winners__winner-right">
                     <h3 class="winners__winner-title">react-testing-library</h3>
-                    <p class="winners__winner-link"><a href="github.com/kentcdodds/react-testing-library">github.com/kentcdodds/react-testing-library</a></p>
+                    <p class="winners__winner-link"><a href="https://github.com/kentcdodds/react-testing-library">github.com/kentcdodds/react-testing-library</a></p>
                     <p class="winners__winner-desc">
                       Simple and complete React DOM testing utilities that encourage good testing practices.
                     </p>
@@ -290,7 +290,7 @@
 
                   <div class="winners__winner-right">
                     <h3 class="winners__winner-title">mdx-deck</h3>
-                    <p class="winners__winner-link"><a href="github.com/jxnblk/mdx-deck">github.com/jxnblk/mdx-deck</a></p>
+                    <p class="winners__winner-link"><a href="https://github.com/jxnblk/mdx-deck">github.com/jxnblk/mdx-deck</a></p>
                     <p class="winners__winner-desc">
                       MDX-based presentation decks.
                     </p>

--- a/react/2020.html
+++ b/react/2020.html
@@ -189,7 +189,7 @@
 
                   <div class="winners__winner-right">
                     <h3 class="winners__winner-title">React Three Fiber</h3>
-                    <p class="winners__winner-link"><a href="github.com/react-spring/react-three-fiber">github.com/react-spring/react-three-fiber</a></p>
+                    <p class="winners__winner-link"><a href="https://github.com/react-spring/react-three-fiber">github.com/react-spring/react-three-fiber</a></p>
                     <p class="winners__winner-desc">
                       A react reconciler for threejs (web and react-native)
                     </p>
@@ -215,7 +215,7 @@
 
                   <div class="winners__winner-right">
                     <h3 class="winners__winner-title">React Adaptive Hooks</h3>
-                    <p class="winners__winner-link"><a href="github.com/GoogleChromeLabs/react-adaptive-hooks">github.com/GoogleChromeLabs/react-adaptive-hooks</a></p>
+                    <p class="winners__winner-link"><a href="https://github.com/GoogleChromeLabs/react-adaptive-hooks">github.com/GoogleChromeLabs/react-adaptive-hooks</a></p>
                     <p class="winners__winner-desc">Deliver experiences best suited to a user's device and network constraints</p>
                   </div>
                 </div>
@@ -239,7 +239,7 @@
 
                   <div class="winners__winner-right">
                     <h3 class="winners__winner-title">Never-Blink</h3>
-                    <p class="winners__winner-link"><a href="github.com/ByronHsu/Never-Blink">github.com/ByronHsu/Never-Blink</a></p>
+                    <p class="winners__winner-link"><a href="https://github.com/ByronHsu/Never-Blink">github.com/ByronHsu/Never-Blink</a></p>
                     <p class="winners__winner-desc">
                       Blink and lose.
                     </p>
@@ -264,7 +264,7 @@
 
                   <div class="winners__winner-right">
                     <h3 class="winners__winner-title">Chakra UI</h3>
-                    <p class="winners__winner-link"><a href="github.com/chakra-ui/chakra-ui">github.com/chakra-ui/chakra-ui</a></p>
+                    <p class="winners__winner-link"><a href="https://github.com/chakra-ui/chakra-ui">github.com/chakra-ui/chakra-ui</a></p>
                     <p class="winners__winner-desc">
                       Simple, Modular & Accessible UI Components for your React Applications
                     </p>
@@ -290,7 +290,7 @@
 
                   <div class="winners__winner-right">
                     <h3 class="winners__winner-title">React Hook Form</h3>
-                    <p class="winners__winner-link"><a href="github.com/react-hook-form/react-hook-form">github.com/react-hook-form/react-hook-form</a></p>
+                    <p class="winners__winner-link"><a href="https://github.com/react-hook-form/react-hook-form">github.com/react-hook-form/react-hook-form</a></p>
                     <p class="winners__winner-desc">
                       React hooks for forms validation without the hassle.
                     </p>

--- a/react/index.html
+++ b/react/index.html
@@ -100,7 +100,7 @@
           <nav class="main-nav">
             <ul class="main-menu">
               <li class="main-menu__item"><a class="main-menu__link" href="#ceremony">Ceremony location</a></li>
-              <li class="main-menu__item"><a class="main-menu__link" href="#nominees">Nominees</a></li>
+              <li class="main-menu__item"><a class="main-menu__link" href="nominees">Nominees</a></li>
               <li class="main-menu__item"><a class="main-menu__link" href="/react/2019">Previous years</a></li>
             </ul>
           </nav>

--- a/reactnative/index.html
+++ b/reactnative/index.html
@@ -100,7 +100,7 @@
           <nav class="main-nav">
             <ul class="main-menu">
                <li class="main-menu__item"><a class="main-menu__link" href="#ceremony">Ceremony location</a></li>
-              <li class="main-menu__item"><a class="main-menu__link" href="#nominees">Nominees</a></li>
+              <li class="main-menu__item"><a class="main-menu__link" href="nominees">Nominees</a></li>
                <!-- <li class="main-menu__item"><a class="main-menu__link" href="/reactnative/nominees">Previous years</a></li> -->
             </ul>
           </nav>

--- a/vue/index.html
+++ b/vue/index.html
@@ -84,7 +84,7 @@
       <nav class="main-nav">
         <ul class="main-menu">
           <li class="main-menu__item"><a class="main-menu__link" href="#ceremony">Ceremony location</a></li>
-          <li class="main-menu__item"><a class="main-menu__link" href="#nominees">Nominees</a></li>
+          <li class="main-menu__item"><a class="main-menu__link" href="nominees">Nominees</a></li>
           <!--                        <li class="main-menu__item"><a class="main-menu__link" href="/vue/nominees">Previous years</a></li>-->
         </ul>
       </nav>

--- a/vue/index.html
+++ b/vue/index.html
@@ -84,7 +84,7 @@
       <nav class="main-nav">
         <ul class="main-menu">
           <li class="main-menu__item"><a class="main-menu__link" href="#ceremony">Ceremony location</a></li>
-          <li class="main-menu__item"><a class="main-menu__link" href="nominees">Nominees</a></li>
+          <li class="main-menu__item"><a class="main-menu__link" href="#nominees">Nominees</a></li>
           <!--                        <li class="main-menu__item"><a class="main-menu__link" href="/vue/nominees">Previous years</a></li>-->
         </ul>
       </nav>


### PR DESCRIPTION
Since the React and JavaScript pages lack a Nominee content thus an anchor, I've updates their links to navigate to their respective Nominees page. Also, some of the project links were missing a protocol prefix, which made the links point relative paths rather than absolute.